### PR TITLE
DOC: update EzPlot Tutorial page

### DIFF
--- a/Jupyter/EzPlot_Example/EzPlot_Example.html
+++ b/Jupyter/EzPlot_Example/EzPlot_Example.html
@@ -3,8 +3,6 @@ layout: default
 title: EzPlot_Example Tutorial
 ---
 
-# EzPlot_Example Tutorial
-[download iPython Notebook](EzPlot_Example.ipynb)
 <!DOCTYPE html>
 <html>
 <head><meta charset="utf-8" />

--- a/Jupyter/EzPlot_Example/EzPlot_Example.html
+++ b/Jupyter/EzPlot_Example/EzPlot_Example.html
@@ -11780,7 +11780,11 @@ div#notebook {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h1 id="EzPlot-Example">EzPlot Example<a class="anchor-link" href="#EzPlot-Example">&#182;</a></h1>
+<h1 id="EzPlot-Example">EzPlot Example<a class="anchor-link" href="#EzPlot-Example">&#182;</a></h1><p>This Notebook demonstrates how to create an EzPlot in VCS</p>
+<ul>
+  <li><a href="EzPlot_Example.ipynb">Download the Jupyter notebook</a></li>
+  </ul>
+  
 </div>
 </div>
 </div>

--- a/Jupyter/PolarPlots/PolarPlots.html
+++ b/Jupyter/PolarPlots/PolarPlots.html
@@ -3,12 +3,10 @@ layout: default
 title: PolarPlots Tutorial
 ---
 
-# PolarPlots Tutorial
-[download iPython Notebook](PolarPlots.ipynb)
 <!DOCTYPE html>
 <html>
 <head><meta charset="utf-8" />
-<title>PolarPlots</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>PolarPlots Tutorial</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 
 <style type="text/css">
@@ -11782,7 +11780,7 @@ div#notebook {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h1 id="Polar-Plots">Polar Plots<a id="top" /><a class="anchor-link" href="#Polar-Plots">&#182;</a></h1><p>This Notebook demonstrates how to create polar plots in VCS</p>
+<h1 id="Polar-Plots">Polar Plots Tutorial<a id="top" /><a class="anchor-link" href="#Polar-Plots">&#182;</a></h1><p>This Notebook demonstrates how to create polar plots in VCS</p>
 <ul>
 <li><a href="PolarPlots.ipynb">Download the Jupyter notebook</a></li>
 </ul>

--- a/contact.md
+++ b/contact.md
@@ -13,49 +13,49 @@ layout: default
 
 Need help? We've got you covered.
 
-If you [subscribe][subscribe] to our support mailing list, [uvcdat-support@llnl.gov][support], you can send us your questions and developers of the project will get back to you as quickly as possible.
+If you [subscribe][subscribe] to our support mailing list, [cdat-support@llnl.gov][support], you can send us your questions and developers of the project will get back to you as quickly as possible.
 
 #### Subscribing to the mailing list
 
 To join the mailing list, send an email to [listserv@listserv.llnl.gov][subscribe] with the following in the body:
 
-    subscribe uvcdat-support
+    subscribe cdat-support
 
 #### Unsubscribing to the mailing list
 
 To leave the mailing list, send an email to [listserv@listserv.llnl.gov][unsubscribe] with the following in the body:
 
-    signoff uvcdat-support
+    signoff cdat-support
 
 
 ---
 
 ### Participate
 
-Interested in working on CDAT with us? [Subscribe][devsub] to our development mailing list, [uvcdat-devel@llnl.gov][devel] and we'll help you get up to speed.
+Interested in working on CDAT with us? [Subscribe][devsub] to our development mailing list, [cdat-dev@llnl.gov][dev] and we'll help you get up to speed.
 
 #### Subscribing to the mailing list
 
 To join the mailing list, send an email to [listserv@listserv.llnl.gov][devsub] with the following in the body:
 
-    subscribe uvcdat-devel
+    subscribe cdat-dev
 
 #### Unsubscribing to the mailing list
 
 To leave the mailing list, send an email to [listserv@listserv.llnl.gov][devunsub] with the following in the body:
 
-    signoff uvcdat-devel
+    signoff cdat-dev
 
 ---
 
-#### See something wrong with the site?
+#### See something wrong with the website?
 
-- [Submit an issue on GitHub](https://github.com/CDAT/uvcdat-site/issues)
+- [Submit an issue on the website GitHub](https://github.com/CDAT/cdat.github.io/issues)
 
 #### Found a bug in CDAT?
 
-- [Submit an issue on GitHub](https://github.com/CDAT/uvcdat/issues)
-- [Send an email to uvcdat-support][support]
+- [Submit an issue on the CDAT GitHub](https://github.com/CDAT/cdat/issues)
+- [Send an email to cdat-support][support]
 
 ---
 
@@ -64,9 +64,9 @@ To leave the mailing list, send an email to [listserv@listserv.llnl.gov][devunsu
 <a href="https://www.youtube.com/results?search_query=UVCDAT"><img class="contact-logo" src="/images/youtube.png" alt="YouTube logo"/></a>
 
 [uvcdat-askbot]:   http://askbot-uvcdat.llnl.gov
-[support]:         mailto:uvcdat-support@llnl.gov
-[devel]:           mailto:uvcdat-devel@llnl.gov
-[devsub]:          mailto:listserv@listserv.llnl.gov?body=subscribe%20uvcdat-devel&amp;subject=Subscribe
-[devunsub]:        mailto:listserv@listserv.llnl.gov?body=signoff%20uvcdat-devel&amp;subject=Unsubscribe
-[subscribe]:       mailto:listserv@listserv.llnl.gov?body=subscribe%20uvcdat-support&amp;subject=Subscribe
-[unsubscribe]:     mailto:listserv@listserv.llnl.gov?body=signoff%20uvcdat-support&amp;subject=Unsubscribe
+[support]:         mailto:cdat-support@llnl.gov
+[dev]:             mailto:cdat-dev@llnl.gov
+[devsub]:          mailto:listserv@listserv.llnl.gov?body=subscribe%20cdat-dev&amp;subject=Subscribe
+[devunsub]:        mailto:listserv@listserv.llnl.gov?body=signoff%20cdat-dev&amp;subject=Unsubscribe
+[subscribe]:       mailto:listserv@listserv.llnl.gov?body=subscribe%20cdat-support&amp;subject=Subscribe
+[unsubscribe]:     mailto:listserv@listserv.llnl.gov?body=signoff%20cdat-support&amp;subject=Unsubscribe

--- a/getting_started.md
+++ b/getting_started.md
@@ -21,7 +21,7 @@ source activate [YOUR_CDAT_CONDA_ENV]
 
 Once you've loaded the environment, you should be able to run the examples. They should output a .png file that has the same image as the example.
 
-We strongly recommend using Jupyter notebook for the tutotrials
+We strongly recommend using Jupyter notebook for the tutotrials.  When you type the command below it is best to have navigated to a folder that contains at least one jupyter notebook (file extention .ipynb).
 
 ~~~
 jupyter-notebook
@@ -62,7 +62,7 @@ vcs.download_sample_data_files()
 # The vcs_canvas is the root object of VCS
 vcs_canvas = vcs.init()
 
-cdms_file = cdms2.open(vcs.prefix + "/sample_data/clt.nc")
+cdms_file = cdms2.open(vcs.prefix + "/share/cdat/sample_data/clt.nc")
 
 # We'll pull a variable out of the netCDF file
 clt_variable = cdms_file("clt")

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ If you want to get to know us, you can come chat with us on our [developer mail 
 <p>
 CDAT builds on the following key technologies:
 <ol>
-  <li>Python and its ecosystem (e.g. numpy, matplotlib);</li>
+  <li>Python and its ecosystem (e.g. NumPy, Matplotlib);</li>
   <li>Jupyter Notebooks and iPython;</li>
   <li>A toolset developed at LLNL for the analysis, visualization, and management of large-scale distributed climate data;</li>
   <li>VTK, the Visualization Toolkit, which is open source software for manipulating and displaying scientific data.</li>
@@ -30,7 +30,7 @@ CDAT builds on the following key technologies:
 <p>
 
 These combined tools, along with others such as the R open-source statistical
-analysis and plotting software and custom packages (e.g. vtDV3D), form CDAT
+analysis and plotting software and custom packages (e.g. DV3D), form CDAT
 and provide a synergistic approach to climate modeling, allowing researchers to
 advance scientific visualization of large-scale climate data sets. The CDAT
 framework couples powerful software infrastructures through two primary means:
@@ -57,11 +57,11 @@ mechanisms to support data analysis.
   <img src="/images/nasa.svg" class="thumbnail" />
 </div>
 
-[gallery]: /gallery.php
-[install]: /installing.html
+[gallery]: /gallery.html
+[install]: https://github.com/CDAT/cdat/wiki/install
 [getting_started]: /getting_started.html
 [support]: mailto:UVCDAT-SUPPORT@LISTSERV.LLNL.GOV?body=subscribe%20uvcdat-support
 [dev]: mailto:UVCDAT-DEVEL@LISTSERV.LLNL.GOV?body=subscribe%20uvcdat-devel
-[wiki]: https://github.com/CDAT/uvcdat/wiki
+[wiki]: https://github.com/CDAT/cdat/wiki
 
 <!-- &amp;subject=Subscribe -->

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ jumbo_text: CDAT is a powerful and complete front-end to a rich set of visual-da
 
 <h2 id="new">Welcome to CDAT!</h2>
 
-New here? Don't worry! We'll help you get started. If you're interested in what you can do with CDAT, you can take a look at our [gallery]. If you're interested in anything you see there, you can look into getting our application [installed][install].
+New here? Don't worry! We'll help you get started. If you're interested in what you can do with CDAT, you can take a look at our [gallery]. If you're interested in anything you see there, you can look into getting our application [installed][install]. Once CDAT has been installed, check out our [Getting Started](http://cdat.llnl.gov/getting_started.html) guide.
 
 <h2 id="help">We'll give you a hand.</h2>
 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ jumbo_text: CDAT is a powerful and complete front-end to a rich set of visual-da
 
 <h2 id="new">Welcome to CDAT!</h2>
 
-New here? Don't worry! We'll help you get started. If you're interested in what you can do with CDAT, you can take a look at our [gallery]. If you're interested in anything you see there, you can look into getting our application [installed][install]. Once CDAT has been installed, check out our [Getting Started](http://cdat.llnl.gov/getting_started.html) guide.
+New here? Don't worry! We'll help you get started. If you're interested in what you can do with CDAT, you can take a look at our [gallery]. If you're interested in anything you see there, you can look into getting our application [installed][install]. Once CDAT has been installed, check out our [Getting Started][getting_started] guide.
 
 <h2 id="help">We'll give you a hand.</h2>
 
@@ -21,10 +21,10 @@ If you want to get to know us, you can come chat with us on our [developer mail 
 <p>
 CDAT builds on the following key technologies:
 <ol>
-  <li>The Community Data Analysis Tools (CDAT) framework developed at LLNL for the analysis, visualization, and management of large-scale distributed climate data;</li>
-  <li>ParaView: an open-source, multi-platform, parallel-capable visualization tool with recently added capabilities to better support specific needs of the climate-science community;</li>
-  <li>VisTrails, an open-source scientific workflow and provenance management system that supports data exploration and visualization;</li>
-  <li>VisIt: an open-source, parallel-capable, visual-data exploration and analysis tool that is capable of running on a diverse set of platforms, ranging from laptops to the Department of Energy's largest supercomputers.</li>
+  <li>Python and its ecosystem (e.g. numpy, matplotlib);</li>
+  <li>Jupyter Notebooks and iPython;</li>
+  <li>A toolset developed at LLNL for the analysis, visualization, and management of large-scale distributed climate data;</li>
+  <li>VTK, the Visualization Toolkit, which is open source software for manipulating and displaying scientific data.</li>
 </ol>
 </p>
 <p>
@@ -36,17 +36,17 @@ advance scientific visualization of large-scale climate data sets. The CDAT
 framework couples powerful software infrastructures through two primary means:
 
 <ol>
-  <li>Tightly coupled integration of the CDAT Core with the VTK/ParaView infrastructure to provide high-performance, parallel-streaming data analysis and visualization of massive climate-data sets (other tighly coupled tools include
-  VCS, VisTrails, DV3D, and ESMF/ESMP);</li>
+  <li>Tightly coupled integration of the CDAT Core with the VTK infrastructure to provide high-performance, parallel-streaming data analysis and visualization of massive climate-data sets (other tighly coupled tools include
+  VCS, DV3D, and ESMF/ESMP);</li>
   <li>Loosely coupled integration to provide the flexibility of using tools quickly
-  in the infrastructure such as ViSUS, VisIt, R, and MatLab for data analysis and
+  in the infrastructure such as ViSUS or R for data analysis and
   visualization as well as to apply customized data analysis applications within
   an integrated environment.</li>
 </ol>
 </p>
 <p>
 Within both paradigms, CDAT will provide data-provenance capture and
-mechanisms to support data analysis via the VisTrails infrastructure.
+mechanisms to support data analysis.
 </p>
 
 <h3>U.S. Sponsors</h3>
@@ -59,6 +59,7 @@ mechanisms to support data analysis via the VisTrails infrastructure.
 
 [gallery]: /gallery.php
 [install]: /installing.html
+[getting_started]: /getting_started.html
 [support]: mailto:UVCDAT-SUPPORT@LISTSERV.LLNL.GOV?body=subscribe%20uvcdat-support
 [dev]: mailto:UVCDAT-DEVEL@LISTSERV.LLNL.GOV?body=subscribe%20uvcdat-devel
 [wiki]: https://github.com/CDAT/uvcdat/wiki

--- a/index.md
+++ b/index.md
@@ -49,6 +49,9 @@ Within both paradigms, CDAT will provide data-provenance capture and
 mechanisms to support data analysis.
 </p>
 
+CDAT is licensed under the [BSD-3][bds3] license.
+
+
 <h3>U.S. Sponsors</h3>
 <div class="sponsor_image">
   <img src="/images/doe.svg" class="thumbnail" />
@@ -60,8 +63,9 @@ mechanisms to support data analysis.
 [gallery]: /gallery.html
 [install]: https://github.com/CDAT/cdat/wiki/install
 [getting_started]: /getting_started.html
-[support]: mailto:UVCDAT-SUPPORT@LISTSERV.LLNL.GOV?body=subscribe%20uvcdat-support
-[dev]: mailto:UVCDAT-DEVEL@LISTSERV.LLNL.GOV?body=subscribe%20uvcdat-devel
+[support]: mailto:CDAT-SUPPORT@LISTSERV.LLNL.GOV?body=subscribe%20cdat-support
+[dev]: mailto:CDAT-DEV@LISTSERV.LLNL.GOV?body=subscribe%20cdat-dev
 [wiki]: https://github.com/CDAT/cdat/wiki
+[bsd3]: https://opensource.org/licenses/BSD-3-Clause
 
 <!-- &amp;subject=Subscribe -->

--- a/installing.md
+++ b/installing.md
@@ -18,3 +18,10 @@ layout: default
 
 * [Binary Installation Instructions (Recommended) <i class="icon icon-globe"></i>](https://github.com/CDAT/uvcdat/wiki/install)
 * [Build from Source Directions <i class="icon icon-globe"></i>](https://github.com/CDAT/uvcdat/wiki/Build)
+
+
+### After Installation
+
+Check out our:
+* [Gallery](http://cdat.llnl.gov/gallery.html) or
+* [Getting Started](http://cdat.llnl.gov/getting_started.html) guide

--- a/tutorials.html
+++ b/tutorials.html
@@ -7,12 +7,20 @@ layout: default
     <h2>Jupyter Tutorials</h2>
     <p>
         To run these examples you will need the nightly Conda build of
-        <a href="https://github.com/CDAT/uvcdat/wiki/Install-using-Anaconda">CDAT</a>
-        <a href="https://github.com/CDAT/uvcdat/wiki/Obtain-UV-CDAT-nightly-packages">installed</a> with Jupyter.
+        <a href="https://github.com/CDAT/uvcdat/wiki/Install-using-Anaconda">CDAT installed</a> with Jupyter.
+    </p>
+    <p>
+        If you are unfamiliar with Jupyter, many resources exist on the web including the <a href ="https://jupyter.org/">Jupyter Project's</a> home page or <a href="https://jupyter.readthedocs.io/en/latest/">Jupyter's Documentation</a> page. 
+    </p>
+    <p>Other learning resources include:
+        <ul><li><a href="https://www.dataquest.io/blog/jupyter-notebook-tutorial/">Dataquest's Jupyter Notebook Tutorial</a></li>
+            <li><a href="https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/">Read the Docs' Jupyter/IPython Notebook Quick Start Guide</a></li>
+            <li><a href="https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook">DataCamp's Jupyter Notebook Tutorial: The Definitive Guide</a></li>
+        </ul>
     </p>
     <div class="container">
         <h3>CDMS</h3>
-        <p> Example on how to use CDMS</p>
+        <p> Examples of how to use CDMS</p>
         <div class="example">
             <a href="Jupyter/cdms2_101/cdms2_101.html">
                 <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
@@ -22,7 +30,7 @@ layout: default
         <div class="example">
             <a href="Jupyter/Redecorate+Transient+Variable/Redecorate+Transient+Variable.html">
                 <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
-                <p>Put Variable Dimensions And Attributes Back tutorial</p>
+                <p>Put variable dimensions and attributes back tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -34,25 +42,25 @@ layout: default
         <div class="example">
             <a href="Jupyter/Creating_Non_Rectiilinear_Grids_From_Scratch/Creating_Non_Rectiilinear_Grids_From_Scratch.html">
                 <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
-                <p>Creating Non Rectilinear Grids From Scratch</p>
+                <p>Creating non rectilinear grids from scratch</p>
             </a>
         </div>
         <div class="example">
             <a href="Jupyter/NetCDF4_Compression/NetCDF4_Compression.html">
                 <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
-                <p>Controling NetCDF4 Files Compression</p>
+                <p>Controling NetCDF4 files compression</p>
             </a>
         </div>
     </div>
     <div class="container">
         <h3>VCS</h3>
-        <p> Example on how to use VCS</p>
+        <p> Examples of how to use VCS</p>
         <div class="example">
             <a href="Jupyter/VCS_Principles/VCS_Principles.html">
                 <div class="img-wrapper">
                     <img src="images/uvcdat.png"/>
                 </div>
-                <p>VCS Principles</p>
+                <p>VCS principles</p>
             </a>
         </div>
         <div class="example">
@@ -68,7 +76,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/VCS_Text_Objects/VCS_Text_Objects.png"/>
                 </div>
-                <p>Text Objects in VCS</p>
+                <p>Text objects in VCS</p>
             </a>
         </div>
         <div class="example">
@@ -76,7 +84,7 @@ layout: default
                 <div class="img-wrapper">
                     <img class="portrait" src="Jupyter/EzTemplates/EzTemplates.png"/>
                 </div>
-                <p>Easily Create Templates for VCS plots</p>
+                <p>Easily create templates for VCS plots</p>
             </a>
         </div>
         <div class="example">
@@ -84,7 +92,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/boxfill/boxfill.png"/>
                 </div>
-                <p>Walkthrough of each attribute of Boxfill</p>
+                <p>Walkthrough of each attribute of boxfill</p>
             </a>
         </div>
         <div class="example">
@@ -100,7 +108,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/Taylor_Diagrams/Taylor_Diagrams.png"/>
                 </div>
-                <p>Taylor Diagrams tutorial</p>
+                <p>Taylor diagrams tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -108,7 +116,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/1D_Multi_line_Plots/1D_Multi_line_Plots.png"/>
                 </div>
-                <p>Line Plots tutorial</p>
+                <p>Line plots tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -116,7 +124,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/Mathematical_Expressions_and_Symbols/Mathematical_Expressions_and_Symbols.png">
                 </div>
-                <p>Mathematical Expressions and Symbols tutorial</p>
+                <p>Mathematical expressions and symbols tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -132,7 +140,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/Colormap_Create/Color_map_create_own.png">
                 </div>
-                <p>Create Colormap</p>
+                <p>Create colormap</p>
             </a>
         </div>
         <div class="example">
@@ -140,7 +148,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/Shading_With_Patterns_in_VCS/Shading_With_Patterns_in_VCS.png">
                 </div>
-                <p>Hatching/Patterns tutorial</p>
+                <p>Hatching/patterns tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -158,35 +166,35 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/Logo_Control/Logo_Control.png">
                 </div>
-                <p>Logo Control tutorial</p>
+                <p>Logo control tutorial</p>
             </a>
         </div>
     </div>
     <div class="container">
         <h3>CDUTIL and GENUTIL</h3>
-        <p> Example on how to use cdutil and genutil</p>
+        <p> Examples of how to use cdutil and genutil</p>
         <div class="example">
             <a href="Jupyter/EasilyCreatingStringsWithTemplating/EasilyCreatingStringsWithTemplating.html">
                 <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
-                <p>Easily Creating Strings With Templating tutorial</p>
+                <p>Easily creating strings with templating tutorial</p>
             </a>
         </div>
         <div class="example">
             <a href="Jupyter/Masking_Data_Land-Sea_masks/Masking_Data_Land-Sea_masks.html">
                 <div class="img-wrapper"><img src="Jupyter/Masking_Data_Land-Sea_masks/Masking_Data_Land-Sea_masks.png"/></div>
-                <p>Masking Data, Creating and Using Masks tutorial</p>
+                <p>Masking data, creating and using masks tutorial</p>
             </a>
         </div>
     </div>
     <div class="container">
         <h3>VCS Adding new plots to CDAT</h3>
-        <p> Example on how to use VCS Addons</p>
+        <p> Examples of how to use VCS Addons</p>
         <div class="example">
             <a href="Jupyter/ParallelCoordinates/ParallelCoordinates.html">
                 <div class="img-wrapper">
                     <img src="Jupyter/ParallelCoordinates/ParallelCoordinates.png"/>
                 </div>
-                <p>Parallel Coordinates (vcs addon) tutorial</p>
+                <p>Parallel coordinates (vcs addon) tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -194,7 +202,7 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/PolarPlots/PolarPlots.png"/>
                 </div>
-                <p>Parallel Coordinates (vcs addon) tutorial</p>
+                <p>Polar coordinates (vcs addon) tutorial</p>
             </a>
         </div>
         <div class="example">
@@ -202,13 +210,13 @@ layout: default
                 <div class="img-wrapper">
                     <img src="Jupyter/EzPlot_Example/EzPlot_Simple2.png"/>
                 </div>
-                <p>Parallel Coordinates (vcs addon) tutorial</p>
+                <p>EzPlot (vcs addon) tutorial</p>
             </a>
         </div>
     </div>
     <div class="container">
         <h3>Science-based Examples (CDAT in action)</h3>
-        <p> Example on how to solve basic scientific problems with CDAT</p>
+        <p> Example of how to solve basic scientific problems with CDAT</p>
         <div class="example">
             <a href="Jupyter/Mask_variable_on_pressure_where_data_are_bellow_the_surface/Mask_variable_on_pressure_where_data_are_bellow_the_surface.html">
                 <div class="img-wrapper">


### PR DESCRIPTION
Removed what looks like markdown code from the EzPlot Tutorial html page since it was showing up incorrectly.