### PR TITLE
Updated some links on the Tutorials.html page

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -80,9 +80,9 @@ layout: default
             </a>
         </div>
         <div class="example">
-            <a href="Jupyter-notebooks/vcs/EzTemplates/EzTemplates.html">
+            <a href="Jupyter-notebooks/vcsaddons/EzTemplates/EzTemplates.html">
                 <div class="img-wrapper">
-                    <img class="portrait" src="Jupyter-notebooks/vcs/EzTemplates/EzTemplates.png"/>
+                    <img class="portrait" src="Jupyter-notebooks/vcsaddons/EzTemplates/EzTemplates.png"/>
                 </div>
                 <p>Easily create templates for VCS plots</p>
             </a>
@@ -190,25 +190,25 @@ layout: default
         <h3>VCS Adding new plots to CDAT</h3>
         <p> Examples of how to use VCS Addons</p>
         <div class="example">
-            <a href="Jupyter-notebooks/cdat_utilities/ParallelCoordinates/ParallelCoordinates.html">
+            <a href="Jupyter-notebooks/vcsaddons/ParallelCoordinates/ParallelCoordinates.html">
                 <div class="img-wrapper">
-                    <img src="Jupyter-notebooks/cdat_utilities/ParallelCoordinates/ParallelCoordinates.png"/>
+                    <img src="Jupyter-notebooks/vcsaddons/ParallelCoordinates/ParallelCoordinates.png"/>
                 </div>
                 <p>Parallel coordinates (vcs addon) tutorial</p>
             </a>
         </div>
         <div class="example">
-            <a href="Jupyter-notebooks/cdat_utilities/PolarPlots/PolarPlots.html">
+            <a href="Jupyter-notebooks/vcsaddons/PolarPlots/PolarPlots.html">
                 <div class="img-wrapper">
-                    <img src="Jupyter-notebooks/cdat_utilities/PolarPlots/PolarPlots.png"/>
+                    <img src="Jupyter-notebooks/vcsaddons/PolarPlots/PolarPlots.png"/>
                 </div>
                 <p>Polar coordinates (vcs addon) tutorial</p>
             </a>
         </div>
         <div class="example">
-            <a href="Jupyter-notebooks/cdat_utilities/EzPlot_Example/EzPlot_Example.html">
+            <a href="Jupyter-notebooks/vcsaddons/EzPlot_Example/EzPlot_Example.html">
                 <div class="img-wrapper">
-                    <img src="Jupyter-notebooks/cdat_utilities/EzPlot_Example/EzPlot_Simple2.png"/>
+                    <img src="Jupyter-notebooks/vcsaddons/EzPlot_Example/EzPlot_Simple2.png"/>
                 </div>
                 <p>EzPlot (vcs addon) tutorial</p>
             </a>


### PR DESCRIPTION
Some of the links to Jupyter Notebooks on the Tutorials.html page referenced the wrong subfolder (cdms, vcsaddons, etc.) so I updated those links based on the file structure in the new Jupyter-notebooks folder/submodule.
Not sure why the images and page links still do not work, but at least once that issue is resolved, the content on the Tutorials.html page should be referenced correctly.

One notebook is missing from the Jupyter-notebooks folder/submodule: Extend_Two_Variables_To_Cover_Same_Time_Domain.

Two other notebooks (Polar_1D and Detrend_Data) have not yet been added to the Tutorials.html page. They will be added at a later point in time once the issue with content not linking properly is fixed.


