### PR TITLE
Make deploy.bash handle older versions of git when updating submodules

### DIFF
--- a/_tools/deploy.bash
+++ b/_tools/deploy.bash
@@ -10,7 +10,9 @@ base_dir=$1;
 media_dir=$base_dir'_site';
 
 cd $base_dir;
-git pull --recurse-submodules;
+git pull;
+git submodule update --init;
+git submodule foreach git pull origin master;
 /usr/local/bin/jekyll b;
 mkdir _site/gallery/thumbnails;
 ./_tools/resize.bash $media_dir;


### PR DESCRIPTION
The command `git pull --recurse-submodules` only works for git versions 1.7.3 and newer.  Instead, deploy.bash should use `git pull` to update the main repo and `git submodule foreach git pull origin master` to update submodules.  The command `git submodule update --init` is used to initialize new submodules added to .gitmodules.