### PR TITLE
Fix link, reorder two examples

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -34,12 +34,6 @@ layout: default
             </a>
         </div>
         <div class="example">
-            <a href="Jupyter-notebooks/cdms/Extend_Two_Variables_To_Cover_Same_Time_Domain/Extend_Two_Variables_To_Cover_Same_Time_Domain.html">
-                <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
-                <p>Take multiple monthly arrays covering different time scales and "grow" them to cover the union time.</p>
-            </a>
-        </div>
-        <div class="example">
             <a href="Jupyter-notebooks/cdms/Creating_Non_Rectiilinear_Grids_From_Scratch/Creating_Non_Rectiilinear_Grids_From_Scratch.html">
                 <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
                 <p>Creating non rectilinear grids from scratch</p>
@@ -77,14 +71,6 @@ layout: default
                     <img src="Jupyter-notebooks/vcs/VCS_Text_Objects/VCS_Text_Objects.png"/>
                 </div>
                 <p>Text objects in VCS</p>
-            </a>
-        </div>
-        <div class="example">
-            <a href="Jupyter-notebooks/vcsaddons/EzTemplates/EzTemplates.html">
-                <div class="img-wrapper">
-                    <img class="portrait" src="Jupyter-notebooks/vcsaddons/EzTemplates/EzTemplates.png"/>
-                </div>
-                <p>Easily create templates for VCS plots</p>
             </a>
         </div>
         <div class="example">
@@ -185,6 +171,12 @@ layout: default
                 <p>Masking data, creating and using masks tutorial</p>
             </a>
         </div>
+        <div class="example">
+            <a href="Jupyter-notebooks/cdat_utilities/Extend_Two_Variables_To_Cover_Same_Time_Domain/Extend_Two_Variables_To_Cover_Same_Time_Domain.html">
+                <div class="img-wrapper"><img src="images/uvcdat.png"/></div>
+                <p>Take multiple monthly arrays covering different time scales and "grow" them to cover the union time.</p>
+            </a>
+        </div>
     </div>
     <div class="container">
         <h3>VCS Adding new plots to CDAT</h3>
@@ -211,6 +203,14 @@ layout: default
                     <img src="Jupyter-notebooks/vcsaddons/EzPlot_Example/EzPlot_Simple2.png"/>
                 </div>
                 <p>EzPlot (vcs addon) tutorial</p>
+            </a>
+        </div>
+        <div class="example">
+            <a href="Jupyter-notebooks/vcsaddons/EzTemplates/EzTemplates.html">
+                <div class="img-wrapper">
+                    <img class="portrait" src="Jupyter-notebooks/vcsaddons/EzTemplates/EzTemplates.png"/>
+                </div>
+                <p>Easily create templates for VCS plots</p>
             </a>
         </div>
     </div>


### PR DESCRIPTION
Fixed broken link for the Extend_Two_Variables_To_Cover_Same_Time_Domain tutorial. Moved that tutorial to the CD Utils section of the Tutorials.html page. Moved the EzTemplates tutorial to the VCS Add Ons section of the Tutorial.html page.
This pull request addresses issue #184.