### PR TITLE
update disclaimer link in footer of CDAT index page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,7 +40,7 @@
         <div class='col-sm-12 footer-links'>
             <a href="https://aims.llnl.gov/">AIMS</a> &bull;
             <a href="http://www.llnl.gov/">LLNL</a> &bull;
-            <a href="https://www.llnl.gov/disclaimer">Privacy &amp; Legal Notice</a> &bull;
+            <a href="https://raw.githubusercontent.com/CDAT/cdat/master/bsd-3-clause.txt">Privacy &amp; Legal Notice</a> &bull;
             <a href="https://www.llnl.gov/disclaimer.html">LLNL-WEB-460691</a> &bull;
             <a href="https://github.com/CDAT/cdat.github.io/issues">Site Issues</a> &bull;
             <a href="contact.html">Contact</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,7 +40,7 @@
         <div class='col-sm-12 footer-links'>
             <a href="https://aims.llnl.gov/">AIMS</a> &bull;
             <a href="http://www.llnl.gov/">LLNL</a> &bull;
-            <a href="https://raw.github.com/CDAT/uvcdat/master/docs/Legal.txt">Privacy &amp; Legal Notice</a> &bull;
+            <a href="https://www.llnl.gov/disclaimer">Privacy &amp; Legal Notice</a> &bull;
             <a href="https://www.llnl.gov/disclaimer.html">LLNL-WEB-460691</a> &bull;
             <a href="https://github.com/CDAT/cdat.github.io/issues">Site Issues</a> &bull;
             <a href="contact.html">Contact</a>

--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ Within both paradigms, CDAT will provide data-provenance capture and
 mechanisms to support data analysis.
 </p>
 
-CDAT is licensed under the [BSD-3][bds3] license.
+CDAT is licensed under the [BSD-3][bsd3] license.
 
 
 <h3>U.S. Sponsors</h3>


### PR DESCRIPTION
The "Privacy & Legal Notice" link was broken on the CDAT index.html page so I updated it to https://www.llnl.gov/disclaimer (per Philip Cameron-Smith).

@doutriaux1 this new link goes to the same place as the LLNL-WEB-460691 link. I'm guessing that is OK. If you think things should be different, let me know.