### PR TITLE
Added link to detrend notebook

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -151,11 +151,11 @@ layout: default
             </div>
             <br>
             <br>
-        <a href="Jupyter-notebooks/vcs/Animations/Animations.html">
-            <p>Animations tutorial</p>
-        </a>
-    </div>
-    <div class="example">
+            <a href="Jupyter-notebooks/vcs/Animations/Animations.html">
+                <p>Animations tutorial</p>
+            </a>
+        </div>
+        <div class="example">
             <a href="Jupyter-notebooks/vcs/Logo_Control/Logo_Control.html">
                 <div class="img-wrapper">
                     <img src="Jupyter-notebooks/vcs/Logo_Control/Logo_Control.png">
@@ -224,12 +224,20 @@ layout: default
     </div>
     <div class="container">
         <h3>Science-based Examples (CDAT in action)</h3>
-        <p> Example of how to solve basic scientific problems with CDAT</p>
+        <p> Examples of how to solve basic scientific problems with CDAT</p>
         <div class="example">
             <a href="Jupyter-notebooks/scientific/Mask_variable_on_pressure_where_data_are_bellow_the_surface/Mask_variable_on_pressure_where_data_are_bellow_the_surface.html">
                 <div class="img-wrapper">
                     <img src="Jupyter-notebooks/scientific/Mask_variable_on_pressure_where_data_are_bellow_the_surface/Mask_variable_on_pressure_where_data_are_bellow_the_surface.png"/></div>
                 <p>Mask a variable on pressure levels where data are below surface</p>
             </a>
-        </div
+        </div>
+        <div class="example">
+            <a href="Jupyter-notebooks/scientific/Detrend_Data/Detrend_data.html">
+                <div class="img-wrapper">
+                    <img src="Jupyter-notebooks/scientific/Detrend_Data/detrend_data_before.png"/></div>
+                <p>Detrend Data</p>
+            </a>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Added link for the Detrend Data Jupyter Notebook to the Tutorials.html page. The image for the new notebook is in a different pull request, https://github.com/CDAT/Jupyter-notebooks/pull/34, since the image lives in a different repo than the Tutorials.html page. Perhaps this pull request should be approved AFTER this one: https://github.com/CDAT/Jupyter-notebooks/pull/34. 

I was going to add @mauzey1, but he is not showing up when I search the list of reviewers. 